### PR TITLE
Forecast cutoff

### DIFF
--- a/aaem/forecast.py
+++ b/aaem/forecast.py
@@ -103,7 +103,7 @@ class Forecast (object):
         population = DataFrame({"year":new_years, 
              "population":growth(years,population,new_years)}).set_index("year")
     
-        population.ix[new_years[0]+15:] =\ 
+        population.ix[new_years[0]+15:] =\
                                     np.float64(population.ix[new_years[0]+15])
         
         self.population = population


### PR DESCRIPTION
added cut off after 15 years to stop exponential growth, as the AEA does with their models internally. Once the ICER population forecast is complete we will use that instead.
